### PR TITLE
Refactor Dockerfile to run pip first

### DIFF
--- a/{{ cookiecutter.app_name }}-serving/Dockerfile
+++ b/{{ cookiecutter.app_name }}-serving/Dockerfile
@@ -5,9 +5,12 @@ RUN apt-get update -y && apt-get install -y build-essential
 RUN conda install --quiet --yes python=3.6.5 && \
     conda clean --all --yes
 
-COPY . $HOME/serving
 WORKDIR $HOME/serving
+
+COPY requirements.txt $HOME/serving
 RUN pip install -r requirements.txt
+
+COPY . $HOME/serving
 
 ENTRYPOINT [ "make" ]
 CMD [ "serve" ]


### PR DESCRIPTION
Rearrange dockerfile flow to make use of cache
So the build will be faster if we only change the source code (will be helpful for debugging)